### PR TITLE
Add alarms and alarm clusters

### DIFF
--- a/galera/meta/heka.yml
+++ b/galera/meta/heka.yml
@@ -18,3 +18,63 @@ log_collector:
       engine: regex
       delimiter: '\n([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})'
       delimiter_eol: false
+metric_collector:
+  trigger:
+    mysql_check:
+      description: 'MySQL cannot be checked'
+      severity: down
+      rules:
+      - metric: mysql_check
+        relational_operator: '=='
+        threshold: 0
+        window: 60
+        periods: 0
+        function: last
+    mysql_node_connected:
+      description: 'The MySQL service has lost connectivity with the other nodes'
+      severity: critical
+      rules:
+      - metric: mysql_cluster_connected
+        relational_operator: '=='
+        threshold: 0
+        window: 30
+        periods: 1
+        function: min
+    mysql_node_ready:
+      description: "The MySQL service isn't ready to serve queries"
+      severity: critical
+      rules:
+      - metric: mysql_cluster_ready
+        relational_operator: '=='
+        threshold: 0
+        window: 30
+        periods: 1
+        function: min
+  alarm:
+    mysql_check:
+      alerting: enabled
+      triggers:
+      - mysql_check
+      dimension:
+        service: mysql
+    mysql_node_status:
+      alerting: enabled
+      triggers:
+      - mysql_node_connected
+      - mysql_node_ready
+      dimension:
+        service: mysql
+aggregator:
+  alarm_cluster:
+    mysql:
+      policy: majority_of_members
+      alerting: enabled_with_notification
+      match:
+        service: mysql
+      group_by: hostname
+      members:
+      - mysql_check
+      - mysql_node_status
+      dimension:
+        cluster_name: mysql
+        nagios_host: 00-top-clusters


### PR DESCRIPTION
This adds alarms and alarm clusters for Galera/MySQL.

With this change the "cluster status" panel works in the Grafana dashboard:

![mysql-dashboard](https://cloud.githubusercontent.com/assets/76594/20562794/d43ac2be-b185-11e6-86c3-8b49707530a0.png)
