### PR TITLE
Change cluster policy to availability_of_members

### DIFF
--- a/galera/meta/heka.yml
+++ b/galera/meta/heka.yml
@@ -67,7 +67,7 @@ metric_collector:
 aggregator:
   alarm_cluster:
     mysql:
-      policy: majority_of_members
+      policy: availability_of_members
       alerting: enabled_with_notification
       match:
         service: mysql


### PR DESCRIPTION
Because the cluster isn't managed by Pacemaker, using
majority_of_members is misleading.