### PR TITLE
Fix mysql with adding ulimit -n 102400

### DIFF
--- a/galera/master.sls
+++ b/galera/master.sls
@@ -45,11 +45,24 @@ galera_run_dir:
   - require:
     - pkg: galera_packages
 
+{%- if grains.get('init', None) == "upstart" %}
+
 galera_purge_init:
   file.absent:
-  - name: /etc/init/mysql.conf
-  - require: 
+  - name: /etc/init.d/mysql
+  - require:
     - pkg: galera_packages
+
+galera_overide:
+  file.managed:
+  - name: /etc/init/mysql.override
+  - contents: |
+      limit nofile 102400 102400
+      exec /usr/bin/mysqld_safe
+  - require:
+    - pkg: galera_packages
+
+{%- endif %}
 
 galera_conf_debian:
   file.managed:

--- a/galera/slave.sls
+++ b/galera/slave.sls
@@ -45,11 +45,24 @@ galera_run_dir:
   - require:
     - pkg: galera_packages
 
+{%- if grains.get('init', None) == "upstart" %}
+
 galera_purge_init:
   file.absent:
-  - name: /etc/init/mysql.conf
+  - name: /etc/init.d/mysql
   - require:
     - pkg: galera_packages
+
+galera_overide:
+  file.managed:
+  - name: /etc/init/mysql.override
+  - contents: |
+      limit nofile 102400 102400
+      exec /usr/bin/mysqld_safe
+  - require:
+    - pkg: galera_packages
+
+{%- endif %}
 
 galera_conf_debian:
   file.managed:


### PR DESCRIPTION
Bug: After deployment of linux formulas and salt states
/etc/security/limits.conf are not applying, as result connections
to mysql failed with error (pymysql.err.OperationalError)
(1040, u'Too many connections')

Solution: create mysql.overide, where ulimit is set to 102400

Closed-bug: PROD-8427