### PR TITLE
Fix case of systemd [Service] unit

### DIFF
--- a/galera/master.sls
+++ b/galera/master.sls
@@ -78,7 +78,7 @@ galera_override_limit_no_file:
   file.managed:
   - name: /etc/systemd/system/mysql.service.d/override.conf
   - contents: |
-      [service]
+      [Service]
       LimitNOFILE=1024000
   - require:
     - pkg: galera_packages

--- a/galera/slave.sls
+++ b/galera/slave.sls
@@ -78,7 +78,7 @@ galera_override_limit_no_file:
   file.managed:
   - name: /etc/systemd/system/mysql.service.d/override.conf
   - contents: |
-      [service]
+      [Service]
       LimitNOFILE=1024000
   - require:
     - pkg: galera_packages


### PR DESCRIPTION
The service unit should have configuration section '[Service]', not '[service]'

Before patch:
```
root@cfg01:~# salt dbs\* cmd.run 'grep files /proc/$(cat /var/run/mysqld/$(hostname).pid)/limits'
dbs01.lab.example.com:
    Max open files            1024              4096              files
dbs02.lab.example.com:
    Max open files            1024              4096              files
dbs03.lab.example.com:
    Max open files            1024              4096              files
```

After patch:
```
root@cfg01:~# salt dbs\* cmd.run 'grep files /proc/$(cat /var/run/mysqld/$(hostname).pid)/limits'
dbs01.lab.example.com:
    Max open files            1024000              1024000              files
dbs02.lab.example.com:
    Max open files            1024000              1024000              files
dbs03.lab.example.com:
    Max open files            1024000              1024000              files
```