### PR TITLE
solve problem "Access denied for user 'root'@'localhost' "

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -3,4 +3,4 @@ suites:
   - name: <%= ENV['SUITE'] %>
     provisioner:
       pillars-from-files:
-        neutron.sls: tests/pillar/<%= ENV['SUITE'] %>.sls
+        galera.sls: tests/pillar/<%= ENV['SUITE'] %>.sls

--- a/galera/files/init_bootstrap.sh
+++ b/galera/files/init_bootstrap.sh
@@ -7,7 +7,7 @@ retries=0
 
 while [ $counter -gt 0 ]
 do
-  mysql -u root -e"quit"
+  mysql -u root -e"quit" || mysql -u {{ service.admin.user }} -p{{ service.admin.password }} -e"quit"
   if [[ $? -eq 0 ]]; then
     echo "Sucessfully connected to the MySQL service ($retries retries)."
     exit 0


### PR DESCRIPTION
I saw, that when I run galera state it fails as it run /usr/share/salt-formulas/env/galera/files/init_bootstrap.sh, this script try to connect to mysql by root without password. I propose to have options - without password (OK for initial run galera state), with password (to perform updates)