### PR TITLE
Added mariadb backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 Usage
 =====
 
-Galera Cluster for MySQL is a true Multimaster Cluster based on synchronous
+Galera Cluster for MySQL or Mariadb is a true Multimaster Cluster based on synchronous
 replication. Galera Cluster is an easy-to-use, high-availability solution,
 which provides high system uptime, no data loss and scalability for future
 growth.
@@ -19,6 +19,7 @@ Galera cluster master node
       version:
         mysql: 5.6
         galera: 3
+      engine: mysql or mariadb
       master:
         enabled: true
         name: openstack
@@ -186,7 +187,7 @@ Usage:
 Usage
 =====
 
-MySQL Galera check sripts
+MySQL/Mariadb Galera check sripts
 
 .. code-block:: bash
 

--- a/galera/files/my.cnf
+++ b/galera/files/my.cnf
@@ -1,3 +1,5 @@
+{% set engine = pillar.galera.get('engine', 'mysql') %}
+
 # All files in this package is subject to the GPL v2 license
 # More information is in the COPYING file in the top directory of this package.
 # Copyright (C) 2011 severalnines.com
@@ -61,6 +63,7 @@ innodb_flush_method=O_DIRECT
 innodb_doublewrite=0
 innodb_autoinc_lock_mode=2
 innodb_locks_unsafe_for_binlog=1
+wsrep_on=ON
 {%- if service.members|length > 1 %}
 wsrep_cluster_address="gcomm://{% for member in service.members %}{{ member.host}}:4567{% if not loop.last %},{% endif %}{% endfor %}/?pc.wait_prim=no"
 {%- else %}
@@ -70,8 +73,10 @@ wsrep_provider={{ service.wsrep_provider }}
 wsrep_cluster_name="openstack"
 
 wsrep_slave_threads={{ service.get('wsrep_slave_threads', 8) }}
+{%- if engine == 'mysql' %}
 wsrep_sst_method=xtrabackup-v2
 wsrep_sst_auth={{ service.admin.user }}:{{ service.admin.password }}
+{%- endif %}
 wsrep_node_address={{ service.bind.address }}
 wsrep_provider_options="gcache.size = 256M"
 wsrep_provider_options="gmcast.listen_addr = tcp://{{ service.bind.address }}:4567"

--- a/galera/init.sls
+++ b/galera/init.sls
@@ -1,11 +1,19 @@
-
+{% set engine = pillar.galera.get('engine', 'mysql') %}
 {%- if pillar.galera is defined %}
 include:
 {%- if pillar.galera.master is defined %}
+  {%- if engine == 'mysql' %}
 - galera.master
+  {%- else %}
+- galera.master_mariadb
+  {%- endif %}
 {%- endif %}
 {%- if pillar.galera.slave is defined %}
+  {%- if engine == 'mysql' %}
 - galera.slave
+  {%- else %}
+- galera.slave_mariadb
+  {%- endif %}
 {%- endif %}
 {%- if pillar.galera.clustercheck is defined %}
 - galera.clustercheck

--- a/galera/map.jinja
+++ b/galera/map.jinja
@@ -1,5 +1,6 @@
 {% set mysql_version  = pillar.galera.get('version', {}).get('mysql', '5.6') %}
 {% set galera_version = pillar.galera.get('version', {}).get('galera', '3')  %}
+{% set engine = pillar.galera.get('engine', 'mysql') %}
 
 {%- load_yaml as master %}
   default:
@@ -7,17 +8,22 @@
     innodb_buffer_pool_size: '3138M'
   Debian:
     pkgs:
+{%- if engine == 'mysql' %}
     - mysql-wsrep-{{ mysql_version }}
+    - python-mysqldb
+    - libdbd-mysql
+    - percona-xtrabackup
+{%- else %}
+    - mariadb-server
+    - mariadb-client
+{%- endif %}
     - galera-{{ galera_version }}
     - rsync
-    - python-mysqldb
     - psmisc
     - netcat
-    - percona-xtrabackup
     - socat
-    - libdbd-mysql
     - python-pymysql
-    service: mysql
+    service: {{ engine }}
     wsrep_provider: /usr/lib/galera/libgalera_smm.so
     log_file: /var/log/mysql.log
     socket: /var/run/mysqld/mysqld.sock
@@ -53,18 +59,23 @@
     innodb_buffer_pool_size: '3138M'
   Debian:
     pkgs:
+{%- if engine == 'mysql' %}
     - mysql-wsrep-{{ mysql_version }}
+    - python-mysqldb
+    - libdbd-mysql
+    - libmysqlclient18
+    - percona-xtrabackup
+{%- else %}
+    - mariadb-server
+    - mariadb-client
+{%- endif %}
     - galera-{{ galera_version }}
     - rsync
-    - python-mysqldb
-    - libmysqlclient18
     - psmisc
     - netcat
-    - percona-xtrabackup
     - socat
-    - libdbd-mysql
     - python-pymysql
-    service: mysql
+    service: {{ engine }}
     wsrep_provider: /usr/lib/galera/libgalera_smm.so
     log_file: /var/log/mysql.log
     socket: /var/run/mysqld/mysqld.sock

--- a/galera/master_mariadb.sls
+++ b/galera/master_mariadb.sls
@@ -1,0 +1,79 @@
+{%- from "galera/map.jinja" import master with context %}
+{%- if master.get('enabled', False) %}
+
+{%- if master.get('ssl', {}).get('enabled', False) %}
+include:
+  - galera._ssl
+{%- endif %}
+
+galera_packages:
+  pkg.installed:
+  - names: {{ master.pkgs }}
+  - refresh: true
+  - force_yes: True
+
+galera_run_dir:
+  file.directory:
+  - name: /var/run/mysqld
+  - makedirs: true
+  - mode: 755
+  - user: mysql
+  - group: root
+  - require:
+    - galera_packages
+
+{%- if salt['cmd.shell']('test -e /etc/salt/.galera_bootstrap; echo $?') != '0'  %}
+
+galera_mariadb_stop_service:
+  service.dead:
+  - name: {{ master.service }}
+
+galera_mariadb_new_cluster:
+  cmd.run:
+  - name: /usr/bin/galera_new_cluster
+  - require:
+    - galera_packages
+    - galera_config
+
+galera_set_root_password:
+  cmd.run:
+  - name: mysqladmin password "{{ master.admin.password }}"
+  {%- if grains.get('noservices') %}
+  - onlyif: /bin/false
+  {%- endif %}
+  - require:
+    - galera_mariadb_new_cluster
+
+mariadb_update_maint_password:
+  cmd.run:
+  - name: mysql -u root -p{{ master.admin.password }} -e "GRANT ALL PRIVILEGES ON *.* TO 'debian-sys-maint'@'localhost' IDENTIFIED BY '{{ master.maintenance_password }}';"
+  {%- if grains.get('noservices') %}
+  - onlyif: /bin/false
+  {%- endif %}
+  - require:
+    - galera_mariadb_new_cluster
+
+galera_mariadb_finish_flag:
+  file.touch:
+  - name: /etc/salt/.galera_bootstrap
+  - require:
+    - galera_mariadb_new_cluster
+
+{%- endif %}
+
+galera_config:
+  file.managed:
+  - name: {{ master.config }}
+  - source: salt://galera/files/my.cnf
+  - mode: 644
+  - template: jinja
+
+mariadb_service_enable:
+  service.running:
+  - name: {{ master.service }}
+  - enable: true
+  - require:
+    - galera_packages
+    - galera_config
+
+{%- endif %}

--- a/galera/slave_mariadb.sls
+++ b/galera/slave_mariadb.sls
@@ -1,0 +1,66 @@
+{%- from "galera/map.jinja" import slave with context %}
+{%- if slave.get('enabled', False) %}
+
+{%- if slave.get('ssl', {}).get('enabled', False) %}
+include:
+  - galera._ssl
+{%- endif %}
+
+galera_packages:
+  pkg.installed:
+  - names: {{ slave.pkgs }}
+  - refresh: true
+  - force_yes: True
+
+galera_run_dir:
+  file.directory:
+  - name: /var/run/mysqld
+  - makedirs: true
+  - mode: 755
+  - user: mysql
+  - group: root
+  - require:
+    - galera_packages
+
+{%- if salt['cmd.shell']('test -e /etc/salt/.galera_bootstrap; echo $?') != '0'  %}
+
+galera_set_root_password:
+  cmd.run:
+  - name: mysqladmin password "{{ slave.admin.password }}"
+  {%- if grains.get('noservices') %}
+  - onlyif: /bin/false
+  {%- endif %}
+
+mariadb_update_maint_password:
+  cmd.run:
+  - name: mysql -u root -p{{ slave.admin.password }} -e "GRANT ALL PRIVILEGES ON *.* TO 'debian-sys-maint'@'localhost' IDENTIFIED BY '{{ slave.maintenance_password }}';"
+  {%- if grains.get('noservices') %}
+  - onlyif: /bin/false
+  {%- endif %}
+
+mariadb_service_dead:
+  service.dead:
+  - name: {{ slave.service }}
+
+galera_mariadb_finish_flag:
+  file.touch:
+  - name: /etc/salt/.galera_bootstrap
+
+{%- endif %}
+
+galera_config:
+  file.managed:
+  - name: {{ slave.config }}
+  - source: salt://galera/files/my.cnf
+  - mode: 644
+  - template: jinja
+
+mariadb_service_enable:
+  service.running:
+  - name: {{ slave.service }}
+  - enable: true
+  - require:
+    - galera_packages
+    - galera_config
+
+{%- endif %}

--- a/tests/pillar/master_cluster.sls
+++ b/tests/pillar/master_cluster.sls
@@ -137,6 +137,7 @@ linux:
           6xiZViPc4VayFnhDIC1w1oBqlhyIZ0AG/D7gqvfYiG6mHO32kPtHEN6Qzny8
           -----END RSA PRIVATE KEY-----
 galera:
+  engine: mariadb
   master:
     enabled: true
     name: galeracluster

--- a/tests/pillar/single.sls
+++ b/tests/pillar/single.sls
@@ -1,4 +1,5 @@
 galera:
+  engine: mariadb
   master:
     enabled: true
     name: galeracluster


### PR DESCRIPTION
Wsrep packages for mysql galera cluster in Ubuntu 18.04 are not available yet in comparison with mariadb. Mariadb packages from version 10.1 contain necessary wsrep funcionality built inside db server engine.
This initial basic mariadb galera implementation has been tested on fresh installation Ubuntu 18.04 and also with install/uninstall cycle successfully.
TODO: 
- no percona-xtrabackup funcionality with mariadb, due to further configuration a testing
